### PR TITLE
[BTH] infra: Configure Cloudflare Pages deploy pipeline

### DIFF
--- a/.github/workflows/deploy-banks-treehouse.yml
+++ b/.github/workflows/deploy-banks-treehouse.yml
@@ -1,0 +1,37 @@
+name: Deploy Banks Treehouse
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'sites/banks-treehouse/**'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: sites/banks-treehouse/package-lock.json
+
+      - name: Install dependencies
+        working-directory: sites/banks-treehouse
+        run: npm ci
+
+      - name: Build
+        working-directory: sites/banks-treehouse
+        run: npx astro build
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy ./sites/banks-treehouse/dist --project-name=banks-treehouse --commit-dirty=true


### PR DESCRIPTION
## Summary
- Added GitHub Actions deploy workflow for banks-treehouse site
- Configured CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID repo secrets
- Workflow triggers on push to main when `sites/banks-treehouse/**` changes

## Issue
Closes #2

## Changes
- `.github/workflows/deploy-banks-treehouse.yml` — new deploy workflow

## Validation
- [x] `npx astro build` passes
- [x] Repo secrets configured

## Note
Cloudflare Pages project creation and custom domain DNS configuration
should be done separately via Cloudflare MCP or dashboard.

---
Generated with [Claude Code](https://claude.com/claude-code)