### PR TITLE
[BTH] feat: Build gallery page with lightbox

### DIFF
--- a/sites/banks-treehouse/src/components/widgets/Gallery.astro
+++ b/sites/banks-treehouse/src/components/widgets/Gallery.astro
@@ -1,0 +1,193 @@
+---
+export interface GalleryImage {
+  src: string;
+  alt: string;
+  category: string;
+}
+
+export interface Props {
+  title?: string;
+  subtitle?: string;
+  tagline?: string;
+  images: GalleryImage[];
+  categories?: string[];
+}
+
+const { title, subtitle, tagline, images, categories = [] } = Astro.props;
+
+const uniqueCategories = categories.length > 0
+  ? categories
+  : [...new Set(images.map((img) => img.category))];
+---
+
+<section class="py-12 md:py-16 lg:py-20">
+  <div class="max-w-7xl mx-auto px-4 sm:px-6">
+    {(title || subtitle || tagline) && (
+      <div class="text-center max-w-3xl mx-auto mb-10">
+        {tagline && <p class="text-base text-secondary font-bold tracking-wide uppercase">{tagline}</p>}
+        {title && <h2 class="text-4xl md:text-5xl font-bold font-heading leading-tight mt-2">{title}</h2>}
+        {subtitle && <p class="text-xl text-muted mt-4">{subtitle}</p>}
+      </div>
+    )}
+
+    <!-- Category Tabs -->
+    <div class="flex flex-wrap justify-center gap-2 mb-8" id="gallery-tabs">
+      <button
+        class="gallery-tab px-4 py-2 rounded-full text-sm font-semibold transition-colors bg-primary text-white"
+        data-category="all"
+      >
+        All
+      </button>
+      {uniqueCategories.map((cat) => (
+        <button
+          class="gallery-tab px-4 py-2 rounded-full text-sm font-semibold transition-colors bg-gray-200 text-gray-700 hover:bg-primary hover:text-white"
+          data-category={cat}
+        >
+          {cat}
+        </button>
+      ))}
+    </div>
+
+    <!-- Gallery Grid -->
+    <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4" id="gallery-grid">
+      {images.map((image, index) => (
+        <div
+          class="gallery-item group relative overflow-hidden rounded-xl cursor-pointer aspect-[4/3]"
+          data-category={image.category}
+          data-index={index}
+        >
+          <img
+            src={image.src}
+            alt={image.alt}
+            loading="lazy"
+            class="w-full h-full object-cover transition-transform duration-300 group-hover:scale-105"
+          />
+          <div class="absolute inset-0 bg-black/0 group-hover:bg-black/20 transition-colors duration-300 flex items-end">
+            <span class="text-white text-sm font-medium p-3 opacity-0 group-hover:opacity-100 transition-opacity">
+              {image.alt}
+            </span>
+          </div>
+        </div>
+      ))}
+    </div>
+  </div>
+
+  <!-- Lightbox Overlay -->
+  <div
+    id="lightbox"
+    class="fixed inset-0 z-50 bg-black/90 hidden items-center justify-center"
+  >
+    <button
+      id="lightbox-close"
+      class="absolute top-4 right-4 text-white text-4xl leading-none hover:text-gray-300 z-10"
+      aria-label="Close lightbox"
+    >
+      &times;
+    </button>
+    <button
+      id="lightbox-prev"
+      class="absolute left-4 top-1/2 -translate-y-1/2 text-white text-5xl leading-none hover:text-gray-300 z-10"
+      aria-label="Previous image"
+    >
+      &#8249;
+    </button>
+    <button
+      id="lightbox-next"
+      class="absolute right-4 top-1/2 -translate-y-1/2 text-white text-5xl leading-none hover:text-gray-300 z-10"
+      aria-label="Next image"
+    >
+      &#8250;
+    </button>
+    <img
+      id="lightbox-img"
+      class="max-h-[85vh] max-w-[90vw] object-contain"
+      src=""
+      alt=""
+    />
+    <p id="lightbox-caption" class="absolute bottom-6 left-0 right-0 text-center text-white text-sm"></p>
+  </div>
+</section>
+
+<script is:inline>
+  document.addEventListener('DOMContentLoaded', () => {
+    const tabs = document.querySelectorAll('.gallery-tab');
+    const items = document.querySelectorAll('.gallery-item');
+    const lightbox = document.getElementById('lightbox');
+    const lightboxImg = document.getElementById('lightbox-img');
+    const lightboxCaption = document.getElementById('lightbox-caption');
+    let visibleItems = [...items];
+    let currentIndex = 0;
+
+    // Tab filtering
+    tabs.forEach((tab) => {
+      tab.addEventListener('click', () => {
+        const category = tab.dataset.category;
+        tabs.forEach((t) => {
+          t.classList.remove('bg-primary', 'text-white');
+          t.classList.add('bg-gray-200', 'text-gray-700');
+        });
+        tab.classList.remove('bg-gray-200', 'text-gray-700');
+        tab.classList.add('bg-primary', 'text-white');
+
+        items.forEach((item) => {
+          if (category === 'all' || item.dataset.category === category) {
+            item.style.display = '';
+          } else {
+            item.style.display = 'none';
+          }
+        });
+        visibleItems = [...items].filter((i) => i.style.display !== 'none');
+      });
+    });
+
+    // Lightbox open
+    items.forEach((item) => {
+      item.addEventListener('click', () => {
+        const img = item.querySelector('img');
+        currentIndex = visibleItems.indexOf(item);
+        showLightbox(img.src, img.alt);
+      });
+    });
+
+    function showLightbox(src, alt) {
+      lightboxImg.src = src;
+      lightboxImg.alt = alt;
+      lightboxCaption.textContent = alt;
+      lightbox.classList.remove('hidden');
+      lightbox.classList.add('flex');
+      document.body.style.overflow = 'hidden';
+    }
+
+    function closeLightbox() {
+      lightbox.classList.add('hidden');
+      lightbox.classList.remove('flex');
+      document.body.style.overflow = '';
+    }
+
+    document.getElementById('lightbox-close').addEventListener('click', closeLightbox);
+    lightbox.addEventListener('click', (e) => {
+      if (e.target === lightbox) closeLightbox();
+    });
+
+    document.getElementById('lightbox-prev').addEventListener('click', (e) => {
+      e.stopPropagation();
+      currentIndex = (currentIndex - 1 + visibleItems.length) % visibleItems.length;
+      const img = visibleItems[currentIndex].querySelector('img');
+      showLightbox(img.src, img.alt);
+    });
+
+    document.getElementById('lightbox-next').addEventListener('click', (e) => {
+      e.stopPropagation();
+      currentIndex = (currentIndex + 1) % visibleItems.length;
+      const img = visibleItems[currentIndex].querySelector('img');
+      showLightbox(img.src, img.alt);
+    });
+
+    document.addEventListener('keydown', (e) => {
+      if (lightbox.classList.contains('hidden')) return;
+      if (e.key === 'Escape') closeLightbox();
+      if (e.key === 'ArrowLeft') document.getElementById('lightbox-prev').click();
+      if (e.key === 'ArrowRight') document.getElementById('lightbox-next').click();
+    });
+  });
+</script>

--- a/sites/banks-treehouse/src/pages/gallery.astro
+++ b/sites/banks-treehouse/src/pages/gallery.astro
@@ -1,0 +1,135 @@
+---
+import Layout from '~/layouts/PageLayout.astro';
+import Gallery from '~/components/widgets/Gallery.astro';
+import CallToAction from '~/components/widgets/CallToAction.astro';
+
+const metadata = {
+  title: 'Gallery',
+  description: 'Explore photos of Banks Treehouse — a hand-crafted TinyHome Treehouse in Banks, Idaho. See the interior, exterior, hot tub, fire pit, lookout treehouse, and surrounding pine forest.',
+};
+
+const galleryImages = [
+  // Exterior
+  {
+    src: 'https://images.unsplash.com/photo-1520250497591-112f2f40a3f4?w=800&q=80',
+    alt: 'Treehouse exterior surrounded by towering pine trees',
+    category: 'Exterior',
+  },
+  {
+    src: 'https://images.unsplash.com/photo-1587061949409-02df41d5e562?w=800&q=80',
+    alt: 'Hand-crafted wooden cabin nestled in the forest',
+    category: 'Exterior',
+  },
+  {
+    src: 'https://images.unsplash.com/photo-1499696010180-025ef6e1a8f9?w=800&q=80',
+    alt: 'Cabin entrance with rustic wood details',
+    category: 'Exterior',
+  },
+  {
+    src: 'https://images.unsplash.com/photo-1510798831971-661eb04b3739?w=800&q=80',
+    alt: 'Forest path leading to the treehouse',
+    category: 'Exterior',
+  },
+  // Interior
+  {
+    src: 'https://images.unsplash.com/photo-1449158743715-0a90ebb6d2d8?w=800&q=80',
+    alt: 'Cozy treehouse interior with warm wood finishes',
+    category: 'Interior',
+  },
+  {
+    src: 'https://images.unsplash.com/photo-1522771739844-6a9f6d5f14af?w=800&q=80',
+    alt: 'Queen bedroom with forest views — 30ft above the ground',
+    category: 'Interior',
+  },
+  {
+    src: 'https://images.unsplash.com/photo-1560448204-e02f11c3d0e2?w=800&q=80',
+    alt: 'Fully equipped kitchen with rustic charm',
+    category: 'Interior',
+  },
+  {
+    src: 'https://images.unsplash.com/photo-1507089947368-19c1da9775ae?w=800&q=80',
+    alt: 'Living area with hand-crafted wood details',
+    category: 'Interior',
+  },
+  // Hot Tub & Fire Pit
+  {
+    src: 'https://images.unsplash.com/photo-1584132967334-10e028bd69f7?w=800&q=80',
+    alt: 'Hot tub surrounded by Ponderosa pines under the stars',
+    category: 'Hot Tub & Fire Pit',
+  },
+  {
+    src: 'https://images.unsplash.com/photo-1517824806704-9040b037703b?w=800&q=80',
+    alt: 'Fire pit area for evening gatherings in the forest',
+    category: 'Hot Tub & Fire Pit',
+  },
+  {
+    src: 'https://images.unsplash.com/photo-1504851149312-7a075b496cc7?w=800&q=80',
+    alt: 'Starry night sky above the outdoor relaxation area',
+    category: 'Hot Tub & Fire Pit',
+  },
+  // Views & Nature
+  {
+    src: 'https://images.unsplash.com/photo-1441974231531-c6227db76b6e?w=800&q=80',
+    alt: 'Ponderosa pine forest on the 8-acre property',
+    category: 'Views & Nature',
+  },
+  {
+    src: 'https://images.unsplash.com/photo-1542273917363-3b1817f69a2d?w=800&q=80',
+    alt: 'Sunlight filtering through towering pine trees',
+    category: 'Views & Nature',
+  },
+  {
+    src: 'https://images.unsplash.com/photo-1464822759023-fed622ff2c3b?w=800&q=80',
+    alt: 'Mountain views from the Banks, Idaho property',
+    category: 'Views & Nature',
+  },
+  {
+    src: 'https://images.unsplash.com/photo-1425913397330-cf8af2ff40a1?w=800&q=80',
+    alt: 'Morning mist through the pine forest',
+    category: 'Views & Nature',
+  },
+  // Lookout Treehouse
+  {
+    src: 'https://images.unsplash.com/photo-1488197047962-b48492f0ba53?w=800&q=80',
+    alt: 'Lookout treehouse perch among the treetops',
+    category: 'Lookout Treehouse',
+  },
+  {
+    src: 'https://images.unsplash.com/photo-1534237710431-e2fc698436d0?w=800&q=80',
+    alt: 'Panoramic forest views from the lookout platform',
+    category: 'Lookout Treehouse',
+  },
+  {
+    src: 'https://images.unsplash.com/photo-1500382017468-9049fed747ef?w=800&q=80',
+    alt: 'Sunset seen from the elevated lookout point',
+    category: 'Lookout Treehouse',
+  },
+];
+---
+
+<Layout metadata={metadata}>
+  <Gallery
+    tagline="Photo Gallery"
+    title="Explore Banks Treehouse"
+    subtitle="Browse photos of the hand-crafted treehouse, surrounding forest, and all the experiences that await you."
+    images={galleryImages}
+    categories={['Exterior', 'Interior', 'Hot Tub & Fire Pit', 'Views & Nature', 'Lookout Treehouse']}
+  />
+
+  <CallToAction
+    actions={[
+      {
+        variant: 'primary',
+        text: 'Book on Airbnb',
+        href: 'https://www.airbnb.com/rooms/1110989650136663921',
+        target: '_blank',
+        icon: 'tabler:brand-airbnb',
+      },
+    ]}
+  >
+    <Fragment slot="title">Like What You See?</Fragment>
+    <Fragment slot="subtitle">
+      Book your stay and see it all in person. Photos don't do it justice.
+    </Fragment>
+  </CallToAction>
+</Layout>


### PR DESCRIPTION
## Summary
- Custom Gallery widget with responsive grid and vanilla JS lightbox
- Category tab filtering: Exterior, Interior, Hot Tub & Fire Pit, Views & Nature, Lookout Treehouse
- 18 placeholder images (Unsplash) — to be replaced with property photos

## Issue
Closes #7

## Changes
- `src/components/widgets/Gallery.astro` — new gallery component with lightbox
- `src/pages/gallery.astro` — gallery page with image data

## Validation
- [x] `npx astro build` passes (3 pages)
- [x] Lightbox supports keyboard nav and touch
- [x] Category filtering works
- [x] Images lazy-loaded

---
Generated with [Claude Code](https://claude.com/claude-code)