### PR TITLE
[BTH] seo: Configure structured data and sitemap

### DIFF
--- a/sites/banks-treehouse/public/robots.txt
+++ b/sites/banks-treehouse/public/robots.txt
@@ -1,2 +1,4 @@
 User-agent: *
-Disallow:
+Allow: /
+
+Sitemap: https://bankstreehouse.com/sitemap-index.xml

--- a/sites/banks-treehouse/src/components/common/StructuredData.astro
+++ b/sites/banks-treehouse/src/components/common/StructuredData.astro
@@ -1,0 +1,71 @@
+---
+const structuredData = {
+  '@context': 'https://schema.org',
+  '@type': 'LodgingBusiness',
+  name: 'Banks Treehouse',
+  description:
+    'A hand-crafted TinyHome Treehouse nestled in 8 acres of Ponderosa pine forest in Banks, Idaho. Hot tub, fire pit, lookout treehouse, and total seclusion.',
+  url: 'https://bankstreehouse.com',
+  image: [
+    'https://images.unsplash.com/photo-1520250497591-112f2f40a3f4?w=1200&q=80',
+  ],
+  address: {
+    '@type': 'PostalAddress',
+    addressLocality: 'Banks',
+    addressRegion: 'ID',
+    addressCountry: 'US',
+  },
+  geo: {
+    '@type': 'GeoCoordinates',
+    latitude: 44.08,
+    longitude: -115.96,
+  },
+  priceRange: '$$',
+  numberOfRooms: 1,
+  checkinTime: '15:00',
+  checkoutTime: '11:00',
+  petsAllowed: false,
+  smokingAllowed: false,
+  amenityFeature: [
+    { '@type': 'LocationFeatureSpecification', name: 'Hot Tub', value: true },
+    { '@type': 'LocationFeatureSpecification', name: 'Fire Pit', value: true },
+    { '@type': 'LocationFeatureSpecification', name: 'WiFi', value: true },
+    { '@type': 'LocationFeatureSpecification', name: 'Full Kitchen', value: true },
+    { '@type': 'LocationFeatureSpecification', name: 'Self Check-in', value: true },
+    { '@type': 'LocationFeatureSpecification', name: 'Lookout Treehouse', value: true },
+    { '@type': 'LocationFeatureSpecification', name: 'Speaker Zones', value: true },
+    { '@type': 'LocationFeatureSpecification', name: 'TV', value: true },
+  ],
+  aggregateRating: {
+    '@type': 'AggregateRating',
+    ratingValue: '4.97',
+    bestRating: '5',
+    worstRating: '1',
+    ratingCount: '111',
+  },
+  containsPlace: {
+    '@type': 'Accommodation',
+    '@id': 'https://bankstreehouse.com/#treehouse',
+    name: 'The Treehouse',
+    description: 'Hand-crafted TinyHome Treehouse with queen bedroom loft, full kitchen, bathroom, and a living Ponderosa pine (Mondo Pondo) intersecting the living space.',
+    occupancy: {
+      '@type': 'QuantitativeValue',
+      value: 2,
+    },
+    numberOfBedrooms: 1,
+    numberOfBathroomsFull: 1,
+    bed: {
+      '@type': 'BedDetails',
+      typeOfBed: 'Queen',
+      numberOfBeds: 1,
+    },
+    floorSize: {
+      '@type': 'QuantitativeValue',
+      unitCode: 'ACR',
+      value: 8,
+    },
+  },
+};
+---
+
+<script type="application/ld+json" set:html={JSON.stringify(structuredData)} />

--- a/sites/banks-treehouse/src/layouts/Layout.astro
+++ b/sites/banks-treehouse/src/layouts/Layout.astro
@@ -11,6 +11,7 @@ import Metadata from '~/components/common/Metadata.astro';
 import SiteVerification from '~/components/common/SiteVerification.astro';
 import Analytics from '~/components/common/Analytics.astro';
 import BasicScripts from '~/components/common/BasicScripts.astro';
+import StructuredData from '~/components/common/StructuredData.astro';
 
 // Comment the line below to disable View Transitions
 import { ClientRouter } from 'astro:transitions';
@@ -35,6 +36,7 @@ const { language, textDirection } = I18N;
     <Metadata {...metadata} />
     <SiteVerification />
     <Analytics />
+    <StructuredData />
 
     <!-- Comment the line below to disable View Transitions -->
     <ClientRouter fallback="swap" />


### PR DESCRIPTION
## Summary
- JSON-LD structured data: LodgingBusiness + Accommodation schema
- Property details: amenities, 4.97 rating, check-in/out, pricing
- Updated robots.txt with sitemap reference
- All pages have unique meta titles and descriptions

## Issue
Closes #16

## Changes
- `src/components/common/StructuredData.astro` — new JSON-LD component
- `src/layouts/Layout.astro` — inject structured data
- `public/robots.txt` — add sitemap URL

## Validation
- [x] `npx astro build` passes (8 pages)
- [x] sitemap-index.xml generated

---
Generated with [Claude Code](https://claude.com/claude-code)